### PR TITLE
Update API calls to remove start parameter. 

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -87,7 +87,7 @@ export const getServiceDependencies = memoizeAsync(
         serviceName: string
         env: string
     } & RequestConfig): Promise<ServiceDependencies> => {
-        const url = `${corsProxy}/https://api.datadoghq.com/api/v1/service_dependencies/${serviceName}?env=${env}&start=0`
+        const url = `${corsProxy}/https://api.datadoghq.com/api/v1/service_dependencies/${serviceName}?env=${env}`
 
         const response = await fetch(url, {
             headers: {


### PR DESCRIPTION
Given our new understanding, see email thread. This will make the extension work for data that is within the last hour, which is better than nothing. 