### PR TITLE
update API call to restore history

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -87,7 +87,7 @@ export const getServiceDependencies = memoizeAsync(
         serviceName: string
         env: string
     } & RequestConfig): Promise<ServiceDependencies> => {
-        const url = `${corsProxy}/https://api.datadoghq.com/api/v1/service_dependencies/${serviceName}?env=${env}`
+        const url = `${corsProxy}/https://api.datadoghq.com/api/v1/service_dependencies/${serviceName}?env=${env}&start=0`
 
         const response = await fetch(url, {
             headers: {


### PR DESCRIPTION
This reverts #2 since that was found to be a small bug with the Datadog API that has now been fixed. 